### PR TITLE
alteração classe r50, escrevearquivo para escrita de r54 e r60I

### DIFF
--- a/SintegraBr/SintegraBr.Classes/Registro54.cs
+++ b/SintegraBr/SintegraBr.Classes/Registro54.cs
@@ -21,8 +21,9 @@ namespace SintegraBr.Classes
         /// <summary>
         /// Código do modelo da nota fiscal
         /// </summary>
-        [SintegraCampos(3, "MODELO", "N", 2, 0, true)]
+        [SintegraCampos(2, "MODELO", "N", 2, 0, true)]
         public int Modelo { get; set; }
+        //alteração gustavo SintegraCampos(3, ... )  -> SintegraCampos(2, ...) 
 
         /// <summary>
         /// Série da nota fiscal

--- a/SintegraBr/SintegraBr.Common/EscreverCamposSintegraByAttribute.cs
+++ b/SintegraBr/SintegraBr.Common/EscreverCamposSintegraByAttribute.cs
@@ -112,21 +112,36 @@ namespace SintegraBr.Common
                                 sb.Append(Convert.ToDateTime(propertyValue).Date.ToString("yyyyMMdd"));
                         else if (isNullableDateTime && hasValue)
                             sb.Append(Convert.ToDateTime(propertyValue).Date.ToString("yyyyMMdd"));
-                        else if (isCode)
-                            sb.Append(propertyValueToStringSafe.PadRight(sintegraCampoAttr.Tamanho, ' '));
-                        else if (isNumber && hasValue)
-                            sb.Append(
-                                propertyValue.ToString()
-                                    .Replace(".", "")
-                                    .Replace(",", "")
-                                    .PadLeft(sintegraCampoAttr.Tamanho, '0'));
-                        else
-                        {
-                            if (propertyLength > 0 && (propertyLength > sintegraCampoAttr.Tamanho))
-                                sb.Append(propertyValueToStringSafe.Substring(0, sintegraCampoAttr.Tamanho));
+                        else 
+                            //adicionado por gustavo - inicio
+                            if (isCode)
+                            {
+                                if (sintegraCampoAttr.Campo == "BRANCOS")
+                                {
+                                    for (int cont = 0; cont < sintegraCampoAttr.Tamanho; cont++)
+                                        sb.Append(" ");
+                                }
+                                else
+                                {
+                                    sb.Append(' ');
+                                }
+                            }//adicionado por gustavo fim
                             else
-                                sb.Append(propertyValueToStringSafe);
-                        }
+                            {
+                                if (isNumber && hasValue)
+                                    sb.Append(
+                                        propertyValue.ToString()
+                                            .Replace(".", "")
+                                            .Replace(",", "")
+                                            .PadLeft(sintegraCampoAttr.Tamanho, '0'));
+                                else
+                                {
+                                    if (propertyLength > 0 && (propertyLength > sintegraCampoAttr.Tamanho))
+                                        sb.Append(propertyValueToStringSafe.Substring(0, sintegraCampoAttr.Tamanho));
+                                    else
+                                        sb.Append(propertyValueToStringSafe);
+                                }
+                            }
                     }
                 }
             }


### PR DESCRIPTION
(1) - adição de campos em branco em emitente r50 (modelo tipo 1 e 1A o emitente "P-próprio , T-terceiros" deve ficar em branco ' ').
(2) - alteração r54 modelo (modelo era exibido no final da linha do sintegra).
(3) - alteração preenchimento de campos em branco r60I - campo brancos (o preenchimento de campos em branco no final do registro r60I não estava sendo feito).
